### PR TITLE
Remove random Console.WriteLine()

### DIFF
--- a/Lidgren.Network/Messaging/Channels/NetReliableSenderChannel.cs
+++ b/Lidgren.Network/Messaging/Channels/NetReliableSenderChannel.cs
@@ -146,8 +146,6 @@ namespace Lidgren.Network
             {
                 if (Interlocked.Decrement(ref storedMessage.Message._recyclingCount) <= 0)
                     _connection.Peer.Recycle(storedMessage.Message);
-                else
-                    Console.WriteLine();
             }
             storedMessage.Reset();
         }


### PR DESCRIPTION
I've checked the project and this is the single and only Console reference in the entire Lidgren.Network project. What the hell is this even doing here?

It keeps messing up my console. Let's get rid of it.