### PR TITLE
Update NetConnection.Handshake.cs

### DIFF
--- a/Lidgren.Network/Connection/NetConnection.Handshake.cs
+++ b/Lidgren.Network/Connection/NetConnection.Handshake.cs
@@ -214,7 +214,7 @@ namespace Lidgren.Network
         {
             if (LocalHailMessage == null)
                 return;
-
+            LocalHailMessage.BitPosition = 0;
             int bitsToAppend = LocalHailMessage.BitLength - LocalHailMessage.BitPosition;
             if (bitsToAppend > 0)
             {


### PR DESCRIPTION
When attempting to write localhaildata for a connection request the hail message will never be sent because the new stream has an end position after writing. This needs reset when writing the hail data.