### PR TITLE
Fix HailData not sending

### DIFF
--- a/Lidgren.Network/Connection/NetConnection.Handshake.cs
+++ b/Lidgren.Network/Connection/NetConnection.Handshake.cs
@@ -214,7 +214,7 @@ namespace Lidgren.Network
         {
             if (LocalHailMessage == null)
                 return;
-
+            LocalHailMessage.BitPosition = 0;
             int bitsToAppend = LocalHailMessage.BitLength - LocalHailMessage.BitPosition;
             if (bitsToAppend > 0)
             {


### PR DESCRIPTION
LocalHailData was not being sent because the position of the stream is at the end when we create hail data. This needs reset back to 0 to set it across the wire.